### PR TITLE
fix: Pillow 10.0.0+ compatibility

### DIFF
--- a/nodes/ImageNode.py
+++ b/nodes/ImageNode.py
@@ -1046,29 +1046,33 @@ def generate_text_image(text,
 
     if layout == "vertical":
         for line in lines:
-            max_char_width = max(font.getsize(char)[0] for char in line)
+            max_char_width = max(font.getbbox(char)[2] - font.getbbox(char)[0] for char in line)
             for char in line:
-                char_width, char_height = font.getsize(char)
+                left, top, right, bottom = font.getbbox(char)
+                char_width = right - left
+                char_height = bottom - top
                 char_coordinates.append((x, y))
                 y += char_height + spacing
                 max_height = max(max_height, y + padding)
             x += max_char_width + line_spacing
             y = padding
         max_width = x
-        total_line_width = sum(font.getsize(line)[1] for line in lines)
+        total_line_width = sum(font.getbbox(line)[2] - font.getbbox(line)[0] for line in lines)
         total_spacing = line_spacing * (len(lines) - 1)
         max_width = total_line_width + total_spacing + padding * 2
     else:
         for line in lines:
-            line_width, line_height = font.getsize(line)
+            line_width, line_height = font.getbbox(line)[2] - font.getbbox(line)[0], font.getbbox(line)[3] - font.getbbox(line)[1]
             for char in line:
-                char_width, char_height = font.getsize(char)
+                left, top, right, bottom = font.getbbox(char)
+                char_width = right - left
+                char_height = bottom - top
                 char_coordinates.append((x, y))
                 x += char_width + spacing
                 max_width = max(max_width, x + padding)
             y += line_height + line_spacing
             x = padding
-        total_line_heights = sum(font.getsize(line)[1] for line in lines)
+        total_line_heights = sum(font.getbbox(line)[3] - font.getbbox(line)[1] for line in lines)
         total_spacing = line_spacing * (len(lines) - 1)
         max_height = total_line_heights + total_spacing + padding * 2
 


### PR DESCRIPTION
Replace deprecated getsize() with getbbox() to support Pillow 10.0.0 and above