### PR TITLE
Fix: Correct scheduler input on StyleAligned Sample Reference Latents node

### DIFF
--- a/nodes/Style.py
+++ b/nodes/Style.py
@@ -234,7 +234,7 @@ class StyleAlignedSampleReferenceLatents:
                     "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                     "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "step":0.1, "round": 0.01}),
 
-                    "scheduler": (comfy.samplers.KSampler.SCHEDULERS.reverse(), ), 
+                    "scheduler": (comfy.samplers.KSampler.SCHEDULERS, ), 
                     "denoise": ("FLOAT", {"default": 1, "min": 0.0, "max": 1.0, "step": 0.01}),
                     
                      }


### PR DESCRIPTION
The scheduler input for the StyleAligned Sample Reference Latents node was defined using a .reverse() method, which caused it to register as an invalid input type that could not accept connections.

This commit changes the input from a broken socket to a dropdown widget, making it consistent with the StyleAligned Reference Sampler node and allowing it to function as intended.