### PR TITLE
Fix: drop handler swallows all drops and breaks ComfyUI native drag&drop

### DIFF
--- a/web/javascript/ui_mixlab.js
+++ b/web/javascript/ui_mixlab.js
@@ -1735,14 +1735,16 @@ app.registerExtension({
 
       // 把json往里 拖
       document.addEventListener('drop', async event => {
-        event.preventDefault()
-        event.stopPropagation()
-
-        // Dragging from Chrome->Firefox there is a file but its a bmp, so ignore that
+        // Only intercept the JSON files handled here. Calling preventDefault()
+        // unconditionally swallowed every drop, so ComfyUI's native drag&drop
+        // (guarded by event.defaultPrevented) never loaded dropped workflows
+        // (PNG / JSON / etc.). Keep preventDefault scoped to the handled case.
         if (
           event.dataTransfer.files.length &&
           event.dataTransfer.files[0].type == 'application/json'
         ) {
+          event.preventDefault()
+          event.stopPropagation()
           const reader = new FileReader()
           reader.onload = async () => {
             loadAppJson(reader.result)


### PR DESCRIPTION
## Bug

With Mixlab installed, **drag & dropping a workflow file (`.json`, `.png`, `.webp`) onto the ComfyUI canvas does nothing** — the workflow never loads.

## Root cause

In `web/javascript/ui_mixlab.js` the document-level `drop` listener calls `event.preventDefault()` and `event.stopPropagation()` **unconditionally**, before checking whether the dropped file is something Mixlab handles:

```js
document.addEventListener('drop', async event => {
  event.preventDefault()
  event.stopPropagation()
  if (event.dataTransfer.files.length &&
      event.dataTransfer.files[0].type == 'application/json') {
    // ... loadAppJson
  }
})
```

ComfyUI's own drop handler (`src/scripts/app.ts` → `addDropHandler`) bails early when the event was already handled:

```js
useEventListener(document, 'drop', async (event) => {
  if (event.defaultPrevented) return   // <- triggered by Mixlab
  ...
})
```

Because Mixlab marks **every** drop as `defaultPrevented`, ComfyUI never loads dropped workflows — and Mixlab itself only handles `application/json`, so PNG/webp workflows (and anything not matching its check) are silently dropped.

### Reproduce
1. Install comfyui-mixlab-nodes.
2. Drag a workflow `.png` or `.json` onto the canvas → nothing loads.
3. Confirm culprit in DevTools: trap `Event.prototype.preventDefault` and log the stack on `type === 'drop'` → stack points to `ui_mixlab.js` drop handler.

## Fix

Scope `preventDefault()` / `stopPropagation()` to the `application/json` branch that Mixlab actually handles. All other drops fall through to ComfyUI's native handler, which already loads JSON/PNG/webp workflows. Mixlab's JSON drag-in behavior is unchanged.

```js
document.addEventListener('drop', async event => {
  if (event.dataTransfer.files.length &&
      event.dataTransfer.files[0].type == 'application/json') {
    event.preventDefault()
    event.stopPropagation()
    // ... loadAppJson
  }
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)